### PR TITLE
Fix the TypeError in Maya 2019, CentOS

### DIFF
--- a/python/screen_grab/screen_grab.py
+++ b/python/screen_grab/screen_grab.py
@@ -322,7 +322,7 @@ def get_desktop_pixmap(rect):
     :rtype: :class:`~PySide.QtGui.QPixmap`
     """
     desktop = QtGui.QApplication.desktop()
-    return QtGui.QPixmap.grabWindow(desktop.winId(), rect.x(), rect.y(),
+    return QtGui.QPixmap.grabWindow(long(desktop.winId()), rect.x(), rect.y(),
                                     rect.width(), rect.height())
 
 


### PR DESCRIPTION
The error:
```
# Traceback (most recent call last):
#   File "/mnt/software/dev/install/app_store/tk-framework-widget/v0.2.7/python/thumbnail_widget/thumbnail_widget.py", line 138, in _on_camera_clicked
#     pm = self._on_screenshot()
#   File "/mnt/software/dev/install/app_store/tk-framework-widget/v0.2.7/python/thumbnail_widget/thumbnail_widget.py", line 230, in _on_screenshot
#     pm = screen_grab.screen_capture()
#   File "/mnt/software/dev/install/app_store/tk-framework-qtwidgets/v2.8.3/python/screen_grab/screen_grab.py", line 181, in screen_capture
#     pixmap = get_desktop_pixmap(tool.capture_rect)
#   File "/mnt/software/dev/install/app_store/tk-framework-qtwidgets/v2.8.3/python/screen_grab/screen_grab.py", line 326, in get_desktop_pixmap
#     rect.width(), rect.height())
# TypeError: # 'PySide2.QtGui.QPixmap.grabWindow' called with wrong argument types:
#   PySide2.QtGui.QPixmap.grabWindow(int, int, int, int, int)
# Supported signatures:
  PySide2.QtGui.QPixmap.grabWindow(quintptr, int = 0, int = 0, int = -1, int = -1)
```